### PR TITLE
fix: bump pygments to 2.20.0

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
 # docs/requirements.txt
 sphinx==7.2.6
 sphinx-autodoc-typehints==1.25.3
-pygments==2.18.0
+pygments==2.20.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "skolemizer"
-version = "2.1.1"
+version = "2.1.2"
 description= "A library with utils for performing Skolemization on blank nodes (RDF)"
 authors = ["Stig B. Dørmænen <stigbd@gmail.com>", "Frederik Rønnevig <frederik.ronnevig@gmail.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
# Summary

- Bump `pygments` from 2.18.0 to 2.20.0 in `docs/requirements.txt` to fix ReDoS vulnerability (Dependabot #52)
- Bump package version to 2.1.2